### PR TITLE
Connects to #24. CDN migration.

### DIFF
--- a/src/features/analysis/analysis.jsx
+++ b/src/features/analysis/analysis.jsx
@@ -174,7 +174,7 @@ function Analysis({
   // for a particular experiment
   function renderForestPlot(tissue) {
     if (inputFetchPayload && inputFetchPayload[tissue] && inputFetchPayload[tissue].data) {
-      const plot = `https://cdn-data-assets.extrameta.org/plots/${tissue}/${geneSymbol.toUpperCase()}.png`;
+      const plot = `https://ds415vxwhii54.cloudfront.net/plots/${tissue}/${geneSymbol.toUpperCase()}.png`;
 
       return (
         <div className="plot-container">

--- a/src/features/analysis/analysisActions.js
+++ b/src/features/analysis/analysisActions.js
@@ -97,16 +97,16 @@ function fetchAnalysisInput(geneSymbol) {
     return axios
       .all([
         axios.get(
-          `https://cdn-data-assets.extrameta.org/input/acute_blood/${geneSymbol.toUpperCase()}.json`
+          `https://ds415vxwhii54.cloudfront.net/input/acute_blood/${geneSymbol.toUpperCase()}.json`
         ).catch(useNull),
         axios.get(
-          `https://cdn-data-assets.extrameta.org/input/acute_muscle/${geneSymbol.toUpperCase()}.json`
+          `https://ds415vxwhii54.cloudfront.net/input/acute_muscle/${geneSymbol.toUpperCase()}.json`
         ).catch(useNull),
         axios.get(
-          `https://cdn-data-assets.extrameta.org/input/longterm_blood/${geneSymbol.toUpperCase()}.json`
+          `https://ds415vxwhii54.cloudfront.net/input/longterm_blood/${geneSymbol.toUpperCase()}.json`
         ).catch(useNull),
         axios.get(
-          `https://cdn-data-assets.extrameta.org/input/longterm_muscle/${geneSymbol.toUpperCase()}.json`
+          `https://ds415vxwhii54.cloudfront.net/input/longterm_muscle/${geneSymbol.toUpperCase()}.json`
         ).catch(useNull),
       ])
       .then(


### PR DESCRIPTION
### Key Changes:

* Changed instances of the GCP CDN URL to AWS CloudFront CDN URL after migrating all static assets to AWS S3 bucket.
* Subsequently will deprecate this GCP CDN with the respective GCS bucket backend.